### PR TITLE
Supports JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ cert -h
 Usage of cert:
   -a    Async mode. Output in no particular order.
   -f string
-        Output format. md as markdown. (default "plain text")
+        Output format. md: as markdown, json: as JSON.  (default "simple table")
 ```
 
 ## License

--- a/cert.go
+++ b/cert.go
@@ -3,6 +3,7 @@ package cert
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"text/template"
@@ -99,6 +100,14 @@ func (certs Certs) Markdown() string {
 		panic(err)
 	}
 	return b.String()
+}
+
+func (certs Certs) JSON() []byte {
+	data, err := json.Marshal(certs)
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 func NewCert(d string) *Cert {

--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var a = flag.Bool("a", false, "Async mode. Output in no particular order.")
-var f = flag.String("f", "plain text", "Output format. md as markdown.")
+var f = flag.String("f", "simple table", "Output format. md: as markdown, json: as JSON. ")
 
 func main() {
 	flag.Parse()

--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -29,6 +29,8 @@ func main() {
 	switch *f {
 	case "md":
 		fmt.Printf("%s", c.Markdown())
+	case "json":
+		fmt.Printf("%s", c.JSON())
 	default:
 		fmt.Printf("%s", c)
 	}


### PR DESCRIPTION
```sh
$cert -f json github.com google.co.jp | jq .
[
  {
    "Error": "",
    "NotAfter": "2018/05/17 21:00:00",
    "NotBefore": "2016/03/10 09:00:00",
    "SANs": [
      "github.com",
      "www.github.com"
    ],
    "CommonName": "github.com",
    "Issuer": "DigiCert Inc",
    "DomainName": "github.com"
  },
  {
    "Error": "",
    "NotAfter": "2017/12/07 02:09:00",
    "NotBefore": "2017/09/14 02:11:49",
    "SANs": [
      "*.google.co.jp",
      "google.co.jp"
    ],
    "CommonName": "*.google.co.jp",
    "Issuer": "Google Inc",
    "DomainName": "google.co.jp"
  }
]
```