### PR TITLE
Add skip verify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cert
 
-Get server cert information.
+Get server's certificate information.
 
 ## Installation
 
@@ -11,8 +11,26 @@ $ go get github.com/genkiroid/cert/...
 ## Usage
 
 ```sh
-$ cert github.com golang.org
+$ cert github.com google.co.jp
+DomainName: github.com
+Issuer:     DigiCert SHA2 Extended Validation Server CA
+NotBefore:  2016/03/10 09:00:00
+NotAfter:   2018/05/17 21:00:00
+CommonName: github.com
+SANs:       [github.com www.github.com]
+Error:
+
+DomainName: google.co.jp
+Issuer:     Google Internet Authority G2
+NotBefore:  2017/09/14 02:11:49
+NotAfter:   2017/12/07 02:09:00
+CommonName: *.google.co.jp
+SANs:       [*.google.co.jp google.co.jp]
+Error:
+
 ```
+
+See help for more options.
 
 ```sh
 $ cert -h
@@ -20,6 +38,7 @@ Usage of cert:
   -a    Async mode. Output in no particular order.
   -f string
         Output format. md: as markdown, json: as JSON.  (default "simple table")
+  -k    Skip verification of server's certificate chain and host name.
 ```
 
 ## License

--- a/cert.go
+++ b/cert.go
@@ -40,8 +40,12 @@ type Cert struct {
 	Error      string
 }
 
+var SkipVerify = false
+
 var serverCert = func(d string) (*x509.Certificate, error) {
-	conn, err := tls.Dial("tcp", d+":443", &tls.Config{})
+	conn, err := tls.Dial("tcp", d+":443", &tls.Config{
+		InsecureSkipVerify: SkipVerify,
+	})
 	if err != nil {
 		return &x509.Certificate{}, err
 	}
@@ -64,7 +68,7 @@ func NewCert(d string) *Cert {
 	}
 	return &Cert{
 		DomainName: d,
-		Issuer:     cert.Issuer.Organization[0],
+		Issuer:     cert.Issuer.CommonName,
 		CommonName: cert.Subject.CommonName,
 		SANs:       cert.DNSNames,
 		NotBefore:  cert.NotBefore.In(time.Local).Format("2006/01/02 15:04:05"),

--- a/cert_test.go
+++ b/cert_test.go
@@ -11,7 +11,7 @@ func stubCert() {
 	serverCert = func(d string) (*x509.Certificate, error) {
 		return &x509.Certificate{
 			Issuer: pkix.Name{
-				Organization: []string{"organization"},
+				CommonName: "CA for test",
 			},
 			Subject: pkix.Name{
 				CommonName: d,
@@ -50,8 +50,8 @@ func TestNewCert(t *testing.T) {
 	if c.DomainName != "example.com" {
 		t.Errorf(`unexpected Cert.DomainName %q, want %q`, c.DomainName, "example.com")
 	}
-	if c.Issuer != "organization" {
-		t.Errorf(`unexpected Cert.Issuer %q, want %q`, c.Issuer, "organization")
+	if c.Issuer != "CA for test" {
+		t.Errorf(`unexpected Cert.Issuer %q, want %q`, c.Issuer, "CA for test")
 	}
 	if c.CommonName != "example.com" {
 		t.Errorf(`unexpected Cert.CommonName %q, want %q`, c.CommonName, "example.com")
@@ -104,7 +104,7 @@ func TestCertsAsString(t *testing.T) {
 	stubCert()
 
 	expected := `DomainName: example.com
-Issuer:     organization
+Issuer:     CA for test
 NotBefore:  2017/01/01 00:00:00
 NotAfter:   2018/01/01 00:00:00
 CommonName: example.com
@@ -126,7 +126,7 @@ func TestCertsAsMarkdown(t *testing.T) {
 
 	expected := `DomainName | Issuer | NotBefore | NotAfter | CN | SANs | Error
 --- | --- | --- | --- | --- | --- | ---
-example.com | organization | 2017/01/01 00:00:00 | 2018/01/01 00:00:00 | example.com | example.com<br/>www.example.com<br/> | 
+example.com | CA for test | 2017/01/01 00:00:00 | 2018/01/01 00:00:00 | example.com | example.com<br/>www.example.com<br/> | 
 
 `
 
@@ -140,7 +140,7 @@ example.com | organization | 2017/01/01 00:00:00 | 2018/01/01 00:00:00 | example
 func TestCertsAsJSON(t *testing.T) {
 	stubCert()
 
-	expected := `[{"DomainName":"example.com","Issuer":"organization","CommonName":"example.com","SANs":["example.com","www.example.com"],"NotBefore":"2017/01/01 00:00:00","NotAfter":"2018/01/01 00:00:00","Error":""}]`
+	expected := `[{"DomainName":"example.com","Issuer":"CA for test","CommonName":"example.com","SANs":["example.com","www.example.com"],"NotBefore":"2017/01/01 00:00:00","NotAfter":"2018/01/01 00:00:00","Error":""}]`
 
 	certs, _ := NewCerts([]string{"example.com"})
 
@@ -153,7 +153,7 @@ func TestCertsEscapeStarInSANs(t *testing.T) {
 	serverCert = func(d string) (*x509.Certificate, error) {
 		return &x509.Certificate{
 			Issuer: pkix.Name{
-				Organization: []string{"organization"},
+				CommonName: "CA for test",
 			},
 			Subject: pkix.Name{
 				CommonName: d,

--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -9,6 +9,7 @@ import (
 )
 
 var a = flag.Bool("a", false, "Async mode. Output in no particular order.")
+var k = flag.Bool("k", false, "Skip verification of server's certificate chain and host name.")
 var f = flag.String("f", "simple table", "Output format. md: as markdown, json: as JSON. ")
 
 func main() {
@@ -16,6 +17,9 @@ func main() {
 
 	var c cert.Certs
 	var err error
+
+	cert.SkipVerify = *k
+
 	if *a {
 		c, err = cert.NewAsyncCerts(flag.Args())
 	} else {


### PR DESCRIPTION
## Verify (default)

```sh
$ cert example.com
DomainName: example.com
Issuer:
NotBefore:
NotAfter:
CommonName:
SANs:       []
Error:      x509: certificate signed by unknown authority
```

## Skip verify (option)

```sh
$ cert -k example.com
DomainName: example.com
Issuer:     Fake LE Intermediate X1
NotBefore:  2017/09/29 13:37:03
NotAfter:   2017/12/28 13:37:03
CommonName: example.com
SANs:       [example.com www.example.com]
Error:
```