### PR TITLE
Use Time.String value for output format

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -71,8 +71,8 @@ func NewCert(d string) *Cert {
 		Issuer:     cert.Issuer.CommonName,
 		CommonName: cert.Subject.CommonName,
 		SANs:       cert.DNSNames,
-		NotBefore:  cert.NotBefore.In(time.Local).Format("2006/01/02 15:04:05"),
-		NotAfter:   cert.NotAfter.In(time.Local).Format("2006/01/02 15:04:05"),
+		NotBefore:  cert.NotBefore.In(time.Local).String(),
+		NotAfter:   cert.NotAfter.In(time.Local).String(),
 		Error:      "",
 	}
 }

--- a/cert_test.go
+++ b/cert_test.go
@@ -17,8 +17,8 @@ func stubCert() {
 				CommonName: d,
 			},
 			DNSNames:  []string{d, "www." + d},
-			NotBefore: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.Local),
-			NotAfter:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.Local),
+			NotBefore: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
+			NotAfter:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
 		}, nil
 	}
 }
@@ -65,11 +65,11 @@ func TestNewCert(t *testing.T) {
 	if c.SANs[1] != "www.example.com" {
 		t.Errorf(`unexpected Cert.SANs[1] %q, want %q`, c.SANs[1], "www.example.com")
 	}
-	if c.NotBefore != "2017/01/01 00:00:00" {
-		t.Errorf(`unexpected Cert.NotBefore %q, want %q`, c.NotBefore, "2017/01/01 00:00:00")
+	if c.NotBefore != "2017-01-01 00:00:00 +0900 JST" {
+		t.Errorf(`unexpected Cert.NotBefore %q, want %q`, c.NotBefore, "2017-01-01 00:00:00 +0900 JST")
 	}
-	if c.NotAfter != "2018/01/01 00:00:00" {
-		t.Errorf(`unexpected Cert.NotAfter %q, want %q`, c.NotAfter, "2018/01/01 00:00:00")
+	if c.NotAfter != "2018-01-01 00:00:00 +0900 JST" {
+		t.Errorf(`unexpected Cert.NotAfter %q, want %q`, c.NotAfter, "2018-01-01 00:00:00 +0900 JST")
 	}
 	if c.Error != "" {
 		t.Errorf(`unexpected Cert.Error %q, want %q`, c.Error, "")
@@ -105,8 +105,8 @@ func TestCertsAsString(t *testing.T) {
 
 	expected := `DomainName: example.com
 Issuer:     CA for test
-NotBefore:  2017/01/01 00:00:00
-NotAfter:   2018/01/01 00:00:00
+NotBefore:  2017-01-01 00:00:00 +0900 JST
+NotAfter:   2018-01-01 00:00:00 +0900 JST
 CommonName: example.com
 SANs:       [example.com www.example.com]
 Error:      
@@ -126,7 +126,7 @@ func TestCertsAsMarkdown(t *testing.T) {
 
 	expected := `DomainName | Issuer | NotBefore | NotAfter | CN | SANs | Error
 --- | --- | --- | --- | --- | --- | ---
-example.com | CA for test | 2017/01/01 00:00:00 | 2018/01/01 00:00:00 | example.com | example.com<br/>www.example.com<br/> | 
+example.com | CA for test | 2017-01-01 00:00:00 +0900 JST | 2018-01-01 00:00:00 +0900 JST | example.com | example.com<br/>www.example.com<br/> | 
 
 `
 
@@ -140,7 +140,7 @@ example.com | CA for test | 2017/01/01 00:00:00 | 2018/01/01 00:00:00 | example.
 func TestCertsAsJSON(t *testing.T) {
 	stubCert()
 
-	expected := `[{"DomainName":"example.com","Issuer":"CA for test","CommonName":"example.com","SANs":["example.com","www.example.com"],"NotBefore":"2017/01/01 00:00:00","NotAfter":"2018/01/01 00:00:00","Error":""}]`
+	expected := `[{"DomainName":"example.com","Issuer":"CA for test","CommonName":"example.com","SANs":["example.com","www.example.com"],"NotBefore":"2017-01-01 00:00:00 +0900 JST","NotAfter":"2018-01-01 00:00:00 +0900 JST","Error":""}]`
 
 	certs, _ := NewCerts([]string{"example.com"})
 
@@ -159,8 +159,8 @@ func TestCertsEscapeStarInSANs(t *testing.T) {
 				CommonName: d,
 			},
 			DNSNames:  []string{d, "*." + d}, // include star
-			NotBefore: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.Local),
-			NotAfter:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.Local),
+			NotBefore: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
+			NotAfter:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
 		}, nil
 	}
 

--- a/cert_test.go
+++ b/cert_test.go
@@ -3,6 +3,7 @@ package cert
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -17,8 +18,8 @@ func stubCert() {
 				CommonName: d,
 			},
 			DNSNames:  []string{d, "www." + d},
-			NotBefore: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
-			NotAfter:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
+			NotBefore: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.Local),
+			NotAfter:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.Local),
 		}, nil
 	}
 }
@@ -43,6 +44,7 @@ func TestNewCert(t *testing.T) {
 	input := "example.com"
 
 	c := NewCert(input)
+	origCert, _ := serverCert(input)
 
 	if _, ok := interface{}(c).(*Cert); !ok {
 		t.Errorf(`NewCert(%q) was not returned *Cert`, input)
@@ -65,11 +67,11 @@ func TestNewCert(t *testing.T) {
 	if c.SANs[1] != "www.example.com" {
 		t.Errorf(`unexpected Cert.SANs[1] %q, want %q`, c.SANs[1], "www.example.com")
 	}
-	if c.NotBefore != "2017-01-01 00:00:00 +0900 JST" {
-		t.Errorf(`unexpected Cert.NotBefore %q, want %q`, c.NotBefore, "2017-01-01 00:00:00 +0900 JST")
+	if c.NotBefore != origCert.NotBefore.String() {
+		t.Errorf(`unexpected Cert.NotBefore %q, want %q`, c.NotBefore, origCert.NotBefore.String())
 	}
-	if c.NotAfter != "2018-01-01 00:00:00 +0900 JST" {
-		t.Errorf(`unexpected Cert.NotAfter %q, want %q`, c.NotAfter, "2018-01-01 00:00:00 +0900 JST")
+	if c.NotAfter != origCert.NotAfter.String() {
+		t.Errorf(`unexpected Cert.NotAfter %q, want %q`, c.NotAfter, origCert.NotAfter.String())
 	}
 	if c.Error != "" {
 		t.Errorf(`unexpected Cert.Error %q, want %q`, c.Error, "")
@@ -103,16 +105,9 @@ func TestNewAsyncCerts(t *testing.T) {
 func TestCertsAsString(t *testing.T) {
 	stubCert()
 
-	expected := `DomainName: example.com
-Issuer:     CA for test
-NotBefore:  2017-01-01 00:00:00 +0900 JST
-NotAfter:   2018-01-01 00:00:00 +0900 JST
-CommonName: example.com
-SANs:       [example.com www.example.com]
-Error:      
+	origCert, _ := serverCert("example.com")
 
-
-`
+	expected := fmt.Sprintf("DomainName: example.com\nIssuer:     CA for test\nNotBefore:  %s\nNotAfter:   %s\nCommonName: example.com\nSANs:       [example.com www.example.com]\nError:      \n\n\n", origCert.NotBefore.String(), origCert.NotAfter.String())
 
 	certs, _ := NewCerts([]string{"example.com"})
 
@@ -124,11 +119,9 @@ Error:
 func TestCertsAsMarkdown(t *testing.T) {
 	stubCert()
 
-	expected := `DomainName | Issuer | NotBefore | NotAfter | CN | SANs | Error
---- | --- | --- | --- | --- | --- | ---
-example.com | CA for test | 2017-01-01 00:00:00 +0900 JST | 2018-01-01 00:00:00 +0900 JST | example.com | example.com<br/>www.example.com<br/> | 
+	origCert, _ := serverCert("example.com")
 
-`
+	expected := fmt.Sprintf("DomainName | Issuer | NotBefore | NotAfter | CN | SANs | Error\n--- | --- | --- | --- | --- | --- | ---\nexample.com | CA for test | %s | %s | example.com | example.com<br/>www.example.com<br/> | \n\n", origCert.NotBefore.String(), origCert.NotAfter.String())
 
 	certs, _ := NewCerts([]string{"example.com"})
 
@@ -140,7 +133,9 @@ example.com | CA for test | 2017-01-01 00:00:00 +0900 JST | 2018-01-01 00:00:00 
 func TestCertsAsJSON(t *testing.T) {
 	stubCert()
 
-	expected := `[{"DomainName":"example.com","Issuer":"CA for test","CommonName":"example.com","SANs":["example.com","www.example.com"],"NotBefore":"2017-01-01 00:00:00 +0900 JST","NotAfter":"2018-01-01 00:00:00 +0900 JST","Error":""}]`
+	origCert, _ := serverCert("example.com")
+
+	expected := fmt.Sprintf("[{\"DomainName\":\"example.com\",\"Issuer\":\"CA for test\",\"CommonName\":\"example.com\",\"SANs\":[\"example.com\",\"www.example.com\"],\"NotBefore\":%q,\"NotAfter\":%q,\"Error\":\"\"}]", origCert.NotBefore.String(), origCert.NotAfter.String())
 
 	certs, _ := NewCerts([]string{"example.com"})
 
@@ -159,8 +154,8 @@ func TestCertsEscapeStarInSANs(t *testing.T) {
 				CommonName: d,
 			},
 			DNSNames:  []string{d, "*." + d}, // include star
-			NotBefore: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
-			NotAfter:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
+			NotBefore: time.Date(2017, time.January, 1, 0, 0, 0, 0, time.Local),
+			NotAfter:  time.Date(2018, time.January, 1, 0, 0, 0, 0, time.Local),
 		}, nil
 	}
 


### PR DESCRIPTION
## Before

```sh
$ cert github.com
DomainName: github.com
Issuer:     DigiCert SHA2 Extended Validation Server CA
NotBefore:  2016/03/10 09:00:00
NotAfter:   2018/05/17 21:00:00
CommonName: github.com
SANs:       [github.com www.github.com]
Error:
```

## After

```sh
$ cert github.com
DomainName: github.com
Issuer:     DigiCert SHA2 Extended Validation Server CA
NotBefore:  2016-03-10 09:00:00 +0900 JST
NotAfter:   2018-05-17 21:00:00 +0900 JST
CommonName: github.com
SANs:       [github.com www.github.com]
Error:
```