### PR TITLE
Enable to specify port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $ go get github.com/genkiroid/cert/...
 
 ## Usage
 
+Give domain names as arguments.
+
 ```sh
 $ cert github.com google.co.jp
 DomainName: github.com
@@ -42,6 +44,40 @@ NotBefore:  2017-10-17 19:59:51 +0900 JST
 NotAfter:   2018-01-09 19:00:00 +0900 JST
 CommonName: *.google.co.jp
 SANs:       [*.google.co.jp google.co.jp]
+Error:
+
+```
+
+You can specify port number.
+So you can get server certificate information of not only web server but also *mail server and others*.
+
+```sh
+$ cert github.com google.co.jp:443 imap.gmail.com:993
+DomainName: github.com
+IP:         192.30.255.113
+Issuer:     DigiCert SHA2 Extended Validation Server CA
+NotBefore:  2016-03-10 09:00:00 +0900 JST
+NotAfter:   2018-05-17 21:00:00 +0900 JST
+CommonName: github.com
+SANs:       [github.com www.github.com]
+Error:
+
+DomainName: google.co.jp
+IP:         172.217.27.163
+Issuer:     Google Internet Authority G3
+NotBefore:  2017-10-17 19:59:51 +0900 JST
+NotAfter:   2018-01-09 19:00:00 +0900 JST
+CommonName: *.google.co.jp
+SANs:       [*.google.co.jp google.co.jp]
+Error:
+
+DomainName: imap.gmail.com
+IP:         64.233.188.108
+Issuer:     Google Internet Authority G2
+NotBefore:  2017-10-17 19:10:29 +0900 JST
+NotAfter:   2017-12-29 09:00:00 +0900 JST
+CommonName: imap.gmail.com
+SANs:       [imap.gmail.com]
 Error:
 
 ```


### PR DESCRIPTION
Enable to get server certificate information of not only web server but also mail server and others.

```sh
$ cert github.com google.co.jp:443 imap.gmail.com:993
DomainName: github.com
IP:         192.30.255.113
Issuer:     DigiCert SHA2 Extended Validation Server CA
NotBefore:  2016-03-10 09:00:00 +0900 JST
NotAfter:   2018-05-17 21:00:00 +0900 JST
CommonName: github.com
SANs:       [github.com www.github.com]
Error:

DomainName: google.co.jp
IP:         172.217.27.163
Issuer:     Google Internet Authority G3
NotBefore:  2017-10-17 19:59:51 +0900 JST
NotAfter:   2018-01-09 19:00:00 +0900 JST
CommonName: *.google.co.jp
SANs:       [*.google.co.jp google.co.jp]
Error:

DomainName: imap.gmail.com
IP:         64.233.188.108
Issuer:     Google Internet Authority G2
NotBefore:  2017-10-17 19:10:29 +0900 JST
NotAfter:   2017-12-29 09:00:00 +0900 JST
CommonName: imap.gmail.com
SANs:       [imap.gmail.com]
Error:

```