### PR TITLE
User template feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Usage of cert:
   -f string
         Output format. md: as markdown, json: as JSON.  (default "simple table")
   -k    Skip verification of server's certificate chain and host name.
+  -t string
+        Output format as Go template string or Go template file path.
   -v    Show version.
   -version
         Show version.

--- a/cert.go
+++ b/cert.go
@@ -166,12 +166,10 @@ func NewCerts(s []string) (Certs, error) {
 
 func (certs Certs) String() string {
 	var b bytes.Buffer
-	var templ string
 
+	templ := defaultTempl
 	if userTempl != "" {
 		templ = userTempl
-	} else {
-		templ = defaultTempl
 	}
 
 	t := template.Must(template.New("default").Parse(templ))

--- a/cert_test.go
+++ b/cert_test.go
@@ -201,3 +201,15 @@ func TestCertsEscapeStarInSANs(t *testing.T) {
 		t.Errorf(`unexpected escaped value %q, want %q`, certs[0].SANs[1], "\\*.example.com")
 	}
 }
+
+func TestSetUserTempl(t *testing.T) {
+	stubCert()
+	_ = SetUserTempl("{{range .}}Issuer: {{.Issuer}}{{end}}")
+	expected := "Issuer: CA for test"
+
+	certs, _ := NewCerts([]string{"example.com"})
+
+	if certs.String() != expected {
+		t.Errorf(`unexpected return value %q, want %q`, certs.String(), expected)
+	}
+}

--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -14,11 +14,13 @@ func main() {
 	var skipVerify bool
 	var format string
 	var showVersion bool
+	var template string
 
 	flag.BoolVar(&skipVerify, "k", false, "Skip verification of server's certificate chain and host name.")
 	flag.StringVar(&format, "f", "simple table", "Output format. md: as markdown, json: as JSON. ")
 	flag.BoolVar(&showVersion, "v", false, "Show version.")
 	flag.BoolVar(&showVersion, "version", false, "Show version.")
+	flag.StringVar(&template, "t", "", "Output format as Go template string or Go template file path.")
 	flag.Parse()
 
 	if showVersion {
@@ -37,12 +39,23 @@ func main() {
 		os.Exit(1)
 	}
 
-	switch format {
-	case "md":
-		fmt.Printf("%s", c.Markdown())
-	case "json":
-		fmt.Printf("%s", c.JSON())
-	default:
+	if template == "" {
+		switch format {
+		case "md":
+			fmt.Printf("%s", c.Markdown())
+		case "json":
+			fmt.Printf("%s", c.JSON())
+		default:
+			fmt.Printf("%s", c)
+		}
+		return
+	}
+
+	if err := cert.SetUserTempl(template); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	} else {
 		fmt.Printf("%s", c)
+		return
 	}
 }

--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -54,8 +54,7 @@ func main() {
 	if err := cert.SetUserTempl(template); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
-	} else {
-		fmt.Printf("%s", c)
-		return
 	}
+
+	fmt.Printf("%s", c)
 }


### PR DESCRIPTION
Implement user template feature. (`-t` option.)

Specify the output format as Go template string directly or template file path.

## Directly

```sh
$cert -t "{{range .}}Issuer: {{.Issuer}}{{end}}" github.com
Issuer: DigiCert SHA2 Extended Validation Server CA
```

## File path

```sh
$cert -t user_templ github.com
Issuer: DigiCert SHA2 Extended Validation Server CA
```