### PR TITLE
Enable to specify cipher suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Error:
 ```sh
 $ cert --help
 Usage of cert:
+  -c string
+        Specify cipher suite. Refer to https://golang.org/pkg/crypto/tls/#pkg-constants for supported cipher suites.
+  -cipher string
+        Specify cipher suite. Refer to https://golang.org/pkg/crypto/tls/#pkg-constants for supported cipher suites.
   -f string
         Output format. md: as markdown, json: as JSON.  (default "simple table")
   -format string
@@ -169,6 +173,40 @@ $
 $ cert -t /tmp/cert_templ github.com
 Issuer: DigiCert SHA2 Extended Validation Server CA
 Issuer: DigiCert High Assurance EV Root CA
+
+```
+
+### Specify cipher suite
+
+see https://github.com/genkiroid/cert/issues/13
+
+You can specify cipher suite.
+As a result, you can get the information of each certificate.
+
+Note that the issuers are different in the following example.
+
+```sh
+# Get information of the certificate using RSA public key algorithm.
+$ cert -cipher TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 cloudflaressl.com
+DomainName: cloudflaressl.com
+IP:         104.20.47.142
+Issuer:     COMODO RSA Domain Validation Secure Server CA 2
+NotBefore:  2019-08-23 09:00:00 +0900 JST
+NotAfter:   2020-03-01 08:59:59 +0900 JST
+CommonName: ssl509631.cloudflaressl.com
+SANs:       [ssl509631.cloudflaressl.com *.cloudflaressl.com cloudflaressl.com]
+Error:
+
+# Get information of the certificate using ECDSA public key algorithm.
+$ cert -cipher TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305 cloudflaressl.com
+DomainName: cloudflaressl.com
+IP:         104.20.48.142
+Issuer:     COMODO ECC Domain Validation Secure Server CA 2
+NotBefore:  2019-08-23 09:00:00 +0900 JST
+NotAfter:   2020-03-01 08:59:59 +0900 JST
+CommonName: ssl509632.cloudflaressl.com
+SANs:       [ssl509632.cloudflaressl.com *.cloudflaressl.com cloudflaressl.com]
+Error:
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Use `cert -t`.
 By direct string.
 
 ```sh
-$ cert -t '{{range .}}{{.Issuer}}{{end}}' github.com
+$ cert -t "{{range .}}{{.Issuer}}{{end}}" github.com
 DigiCert SHA2 Extended Validation Server CA
 ```
 

--- a/cert_test.go
+++ b/cert_test.go
@@ -265,6 +265,22 @@ func TestCertChain(t *testing.T) {
 	}
 }
 
+func TestCipherSuite(t *testing.T) {
+	CipherSuite = "TLS_CHACHA20_POLY1305_SHA256"
+	if _, err := cipherSuite(); err != nil {
+		t.Errorf(`unexpected err %s, want nil`, err.Error())
+	}
+}
+
+func TestCipherSuiteError(t *testing.T) {
+	CipherSuite = "UNSUPPORTED_CIPHER_SUITE"
+	if _, err := cipherSuite(); err == nil {
+		t.Error(`unexpected nil, want error`)
+	} else if err.Error() != "UNSUPPORTED_CIPHER_SUITE is unsupported cipher suite." {
+		t.Errorf(`unexpected err message, want %q`, "UNSUPPORTED_CIPHER_SUITE is unsupported cipher suite.")
+	}
+}
+
 func TestMain(m *testing.M) {
 	setup()
 	os.Exit(m.Run())

--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -17,6 +17,7 @@ func main() {
 	var utc bool
 	var timeout int
 	var showVersion bool
+	var cipherSuite string
 
 	flag.StringVar(&format, "f", "simple table", "Output format. md: as markdown, json: as JSON. ")
 	flag.StringVar(&format, "format", "simple table", "Output format. md: as markdown, json: as JSON. ")
@@ -30,6 +31,8 @@ func main() {
 	flag.IntVar(&timeout, "timeout", 3, "Timeout seconds.")
 	flag.BoolVar(&showVersion, "v", false, "Show version.")
 	flag.BoolVar(&showVersion, "version", false, "Show version.")
+	flag.StringVar(&cipherSuite, "c", "", "Specify cipher suite. Refer to https://golang.org/pkg/crypto/tls/#pkg-constants for supported cipher cuites.")
+	flag.StringVar(&cipherSuite, "cipher", "", "Specify cipher suite. Refer to https://golang.org/pkg/crypto/tls/#pkg-constants for supported cipher cuites.")
 	flag.Parse()
 
 	if showVersion {
@@ -43,6 +46,7 @@ func main() {
 	cert.SkipVerify = skipVerify
 	cert.UTC = utc
 	cert.TimeoutSeconds = timeout
+	cert.CipherSuite = cipherSuite
 
 	certs, err = cert.NewCerts(flag.Args())
 	if err != nil {

--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -31,8 +31,8 @@ func main() {
 	flag.IntVar(&timeout, "timeout", 3, "Timeout seconds.")
 	flag.BoolVar(&showVersion, "v", false, "Show version.")
 	flag.BoolVar(&showVersion, "version", false, "Show version.")
-	flag.StringVar(&cipherSuite, "c", "", "Specify cipher suite. Refer to https://golang.org/pkg/crypto/tls/#pkg-constants for supported cipher cuites.")
-	flag.StringVar(&cipherSuite, "cipher", "", "Specify cipher suite. Refer to https://golang.org/pkg/crypto/tls/#pkg-constants for supported cipher cuites.")
+	flag.StringVar(&cipherSuite, "c", "", "Specify cipher suite. Refer to https://golang.org/pkg/crypto/tls/#pkg-constants for supported cipher suites.")
+	flag.StringVar(&cipherSuite, "cipher", "", "Specify cipher suite. Refer to https://golang.org/pkg/crypto/tls/#pkg-constants for supported cipher suites.")
 	flag.Parse()
 
 	if showVersion {


### PR DESCRIPTION
see https://github.com/genkiroid/cert/issues/13

Now we can specify cipher suite.
As a result, we can get the information of each certificate.

Note that the issuers are different in the following example.

```sh
# Get information of the certificate using RSA public key algorithm.
$ cert -cipher TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305 cloudflaressl.com
DomainName: cloudflaressl.com
IP:         104.20.47.142
Issuer:     COMODO RSA Domain Validation Secure Server CA 2
NotBefore:  2019-08-23 09:00:00 +0900 JST
NotAfter:   2020-03-01 08:59:59 +0900 JST
CommonName: ssl509631.cloudflaressl.com
SANs:       [ssl509631.cloudflaressl.com *.cloudflaressl.com cloudflaressl.com]
Error:

# Get information of the certificate using ECDSA public key algorithm.
$ cert -cipher TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305 cloudflaressl.com
DomainName: cloudflaressl.com
IP:         104.20.48.142
Issuer:     COMODO ECC Domain Validation Secure Server CA 2
NotBefore:  2019-08-23 09:00:00 +0900 JST
NotAfter:   2020-03-01 08:59:59 +0900 JST
CommonName: ssl509632.cloudflaressl.com
SANs:       [ssl509632.cloudflaressl.com *.cloudflaressl.com cloudflaressl.com]
Error:

```
