### PR TITLE
Control tls max version when specify cipher suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Error:
 
 ```
 
+**If you specify a cipher suite, the maximum TLS version used is limited to TLS1.2. This is because if the server supports TLS1.3, the specified cipher suite is ignored and communication is performed using TLS1.3. This eliminates the meaning of specifying a cipher suite and confuses us. This specification will change when the cipher suite for tls1.3 becomes configurable in Go.**
+
 ## License
 
 [MIT](https://github.com/genkiroid/cert/blob/master/LICENSE)


### PR DESCRIPTION
If you specify a cipher suite, the maximum TLS version used is limited to TLS1.2. 
This is because if the server supports TLS1.3, the specified cipher suite is ignored and communication is performed using TLS1.3.
This eliminates the meaning of specifying a cipher suite and confuses us.

This specification will change when the cipher suite for tls1.3 becomes configurable in Go.