### PR TITLE
Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ $ brew install cert
 
 For other platforms, Precompiled binaries for released versions are available in the [releases](https://github.com/genkiroid/cert/releases) page.
 
-Or `go get`.
+Or `go install`.
 
 ```sh
-$ go get github.com/genkiroid/cert/...
+$ go install github.com/genkiroid/cert/cmd/cert@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Fixed installation commands in README.

Installation executables by `go get`
- is deprecated in 1.17. https://go.dev/doc/go1.17#go-get
- no longer works in 1.18 https://go.dev/doc/go1.18#go-get

Installation by `go install` is available from 1.16 (released 2021-02-16).
It seems recent, but 1.16 is no longer supported.
