### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/genkiroid/cert
+
+go 1.19


### PR DESCRIPTION
Hi @genkiroid.

I would like to put `go.mod` in accordance with recent Go language conventions.

How do you like it?