### PR TITLE
Trim scheme and path ( and username:password ) from args for supporting cert checks straight from the URL

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -83,7 +83,6 @@ func SplitHostPort(hostport string) (string, string, error) {
 		if err != nil {
 			return "", "", err
 		}
-		fmt.Printf("u.Host: %s\n", u.Host)
 		hostport = u.Host
 	}
 	if !strings.Contains(hostport, ":") {

--- a/cert.go
+++ b/cert.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,6 +78,14 @@ func SetUserTempl(templ string) error {
 const defaultPort = "443"
 
 func SplitHostPort(hostport string) (string, string, error) {
+	if strings.Contains(hostport, "://") {
+		u, err := url.Parse(hostport)
+		if err != nil {
+			return "", "", err
+		}
+		fmt.Printf("u.Host: %s\n", u.Host)
+		hostport = u.Host
+	}
 	if !strings.Contains(hostport, ":") {
 		return hostport, defaultPort, nil
 	}

--- a/cert_test.go
+++ b/cert_test.go
@@ -74,6 +74,8 @@ func TestSplitHostPort(t *testing.T) {
 		{"smtp.example.com:465", want{"smtp.example.com", "465", ""}},
 		{"example.com:", want{"example.com", defaultPort, ""}},
 		{"example.com::", want{"", "", "address example.com::: too many colons in address"}},
+		{"https://example.com", want{"example.com", defaultPort, ""}},
+		{"https://example.com/path/to", want{"example.com", defaultPort, ""}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Hi @genkiroid.

I want to check certs straight from the URL.
So trim scheme and path ( and username:password ) from args.

```console
$ go run ./cmd/cert/main.go example.com
DomainName: example.com
IP:         2606:2800:220:1:248:1893:25c8:1946
Issuer:     DigiCert TLS RSA SHA256 2020 CA1
NotBefore:  2022-03-14 09:00:00 +0900 JST
NotAfter:   2023-03-15 08:59:59 +0900 JST
CommonName: www.example.org
SANs:       [www.example.org example.net example.edu example.com example.org www.example.com www.example.edu www.example.net]
Error:


$ go run ./cmd/cert/main.go https://example.com
u.Host: example.com
DomainName: example.com
IP:         93.184.216.34
Issuer:     DigiCert TLS RSA SHA256 2020 CA1
NotBefore:  2022-03-14 09:00:00 +0900 JST
NotAfter:   2023-03-15 08:59:59 +0900 JST
CommonName: www.example.org
SANs:       [www.example.org example.net example.edu example.com example.org www.example.com www.example.edu www.example.net]
Error:


$
```